### PR TITLE
Kicad5 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ node_modules
 output
 .DS_Store
 yarn-error.log
+
+.idea/.gitignore
+.idea/kbpcb.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+package-lock.json

--- a/src/kicad.js
+++ b/src/kicad.js
@@ -33,18 +33,9 @@ class KiCad {
     [...Array(keyboard.cols+1)].forEach((_, i) => NetRepo.add(`/col${i}`));
     [...Array(keyboard.rows+1)].forEach((_, i) => NetRepo.add(`/row${i}`));
 
-    let uniques = new Set();
-
+    let i = 1
     keyboard.forEach(k => {
-      k.name.replace(/[^\x00-\x7F]/g, "");
-
-      let i = 1;
-      let candidate = `${k.name}_${i}`;
-      while(uniques.has(candidate)){
-        i++;
-        candidate = `${k.name}_${i}`;
-      }
-      k.name = candidate;
+      k.name = `${i++}`;
 
       const theSwitch = new Switch(k, this.leds);
       const diode     = new Diode(k);

--- a/src/kicad.js
+++ b/src/kicad.js
@@ -34,6 +34,8 @@ class KiCad {
     [...Array(keyboard.rows+1)].forEach((_, i) => NetRepo.add(`/row${i}`));
 
     keyboard.forEach(k => {
+      k.name.replace(/[^\x00-\x7F]/g, "");
+
       const theSwitch = new Switch(k, this.leds);
       const diode     = new Diode(k);
       theSwitch.connectPads(2, diode, 2);

--- a/src/kicad.js
+++ b/src/kicad.js
@@ -33,8 +33,18 @@ class KiCad {
     [...Array(keyboard.cols+1)].forEach((_, i) => NetRepo.add(`/col${i}`));
     [...Array(keyboard.rows+1)].forEach((_, i) => NetRepo.add(`/row${i}`));
 
+    let uniques = new Set();
+
     keyboard.forEach(k => {
       k.name.replace(/[^\x00-\x7F]/g, "");
+
+      let i = 1;
+      let candidate = `${k.name}_${i}`;
+      while(uniques.has(candidate)){
+        i++;
+        candidate = `${k.name}_${i}`;
+      }
+      k.name = candidate;
 
       const theSwitch = new Switch(k, this.leds);
       const diode     = new Diode(k);

--- a/src/zip.js
+++ b/src/zip.js
@@ -4,10 +4,11 @@ const JSZip = require('jszip');
 const addFolder = (files, folder) => {
   fs.readdirSync(`${folder}`).forEach(file => {
     const fileName = `${folder}/${file}`;
+    const fileNameWithoutFootprint = fileName.replace("footprints/", "");
     if (fs.lstatSync(`${fileName}`).isDirectory()) {
       addFolder(files, fileName);
     } else {
-      files.push([fileName, fs.readFileSync(`${fileName}`, 'utf8')]);
+      files.push([fileNameWithoutFootprint, fs.readFileSync(`${fileName}`, 'utf8')]);
     }
   });
 }

--- a/templates/fp-lib-table
+++ b/templates/fp-lib-table
@@ -1,4 +1,4 @@
 (fp_lib_table
-  (lib (name MX_ALPS_Hybrid)(type KiCad)(uri ${KIPRJMOD}/MX_ALPS_Hybrid.pretty)(options "")(descr ""))
+  (lib (name MX_Alps_Hybrid)(type KiCad)(uri ${KIPRJMOD}/MX_Alps_Hybrid.pretty)(options "")(descr ""))
   (lib (name keyboard_parts)(type KiCad)(uri ${KIPRJMOD}/keyboard_parts.pretty)(options "")(descr ""))
 )


### PR DESCRIPTION
I had some problems with kicad5. I tried to fix them. it turns out it was not that related to kicad5 but this fixes some errors:

- MX_ALPS -> MX_Alps: Kicad imports correctly but does not bind the footprint to symbol correctly.
- I had some keys with the same name it was creating errors on designing the PCB. so changed it.
- My local branches were creating the footprints folder. I tried to fix it, needs testing on other machines. (I tested on Mac and Win)
- Added gitignore for "idea" based IDEs (Jetbrains stuff.)